### PR TITLE
Add a reminder to update API documentations to pr template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -35,7 +35,7 @@ deployed.
 
 Things to consider here:
 
-- Documentation updates
+- Documentation updates: Confluence, Postman, OpenAPI specs, release notes
 - Test updates
 - Backfills
 - Monitoring updates


### PR DESCRIPTION
Jira Ticket Number: None

## What does this PR accomplish?

ADds an explicit reminder to update API documentation

## How did you test it?

I'll test post-merge

## How will you know that this is working after deployment?

Create a fake PR and see that the update was applied.

## Any outstanding items or follow ups with Jira tickets?
None.