### PR TITLE
Remove last two questions in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -24,21 +24,5 @@ Consider the following testing approaches:
 - Terraform Workspace
 - Integration Tests
 
-## How will you know that this is working after deployment?
-
-**REQUIRED**
-
-Describe what steps will be taken to be confident that this code is behaving as expected once it is
-deployed.
-
-## Any outstanding items or follow ups with Jira tickets?
-
-Things to consider here:
-
-- Documentation updates: Confluence, Postman, OpenAPI specs, release notes
-- Test updates
-- Backfills
-- Monitoring updates
-
 _NOTE:_ This template comes from [here](https://github.com/zeus-health/.github/blob/main/PULL_REQUEST_TEMPLATE.md).
 If you would like to suggest modifications to this template, open a PR.


### PR DESCRIPTION
[NOJIRA]

## What does this PR accomplish?

This PR removes the third and fourth questions from the org-wide PR template.

Last fall, we introduced this PR template as a response to incidents that were caused by developers deploying bugs into production and leaving those bugs in production for awhile due to inadequate monitoring of changed behavior.

After several months of using this PR template across the company, we have continued to have incidents where developers did not ensure that their changes were properly deployed.

As one of the more prolific PR reviewers in the org, I personally find that the last two questions in the template add more overhead while not reducing problems.

The optional question about follow-up items is almost always blank, "N/A", or removed (I just looked at 10 random recent PRs across repos, and this was the case for 10/10 of them). Given how sparse this is, I think this question should be removed to reduce overhead, and people can feel free to add follow-up items if they wish.

The required question "How will you know this is working after deployment?" is also problematic because
1. The answers to this question are generally of poor quality (of the 10 PRs I just checked, five were empty, removed, or "N/A"; three were uninformative ("e2e tests", "logs will go down", "nothing will happen")
2. Developers' natural workflow does not involve going back through PRs that have already been merged and seeing if the actions to take post-deployment were performed.

We use Jira for our issue tracking system. Requiring developers to verify their changes prior to resolving a ticket gets around the second problem above. If we enforce the ticket resolution requirement, that is superior to keeping the third question in this PR template, and we should not make developers do redundant work.

Sometimes developers use the third question as a way to describe what the expected behavior changes are. However, I believe that is the wrong interpretation of the question. "How does htis affect production?" is not the same as "How will you know this is working in production?". The answer to "How does this affect production?" should already be answered in "What does this PR accomplish?" because you should already be thinking about production behavior when writing your code.

## How did you test it?

I have not tested because this is a change that only requires code review and stakeholder buy-in.

## Notes

Also see action items from [this postmortem](https://zeushealth.atlassian.net/wiki/spaces/ENG/pages/2152562689)